### PR TITLE
Improved error handling and gosec compliance

### DIFF
--- a/kdf.go
+++ b/kdf.go
@@ -1,7 +1,7 @@
 package srp
 
 import (
-	"crypto/sha1"
+	"crypto/sha1" // #nosec
 	"math/big"
 	"strings"
 	"unicode"
@@ -32,13 +32,13 @@ func KDFRFC5054(salt []byte, username string, password string) (x *big.Int) {
 
 	u := []byte(PreparePassword(username))
 
-	innerHasher := sha1.New()
+	innerHasher := sha1.New() // #nosec
 	innerHasher.Write(u)
 	innerHasher.Write([]byte(":"))
 	innerHasher.Write(p)
 	ih := innerHasher.Sum(nil)
 
-	oHasher := sha1.New()
+	oHasher := sha1.New() // #nosec
 	oHasher.Write(salt)
 	oHasher.Write(ih)
 

--- a/kdf.go
+++ b/kdf.go
@@ -1,7 +1,7 @@
 package srp
 
 import (
-	"crypto/sha1" // #nosec
+	"crypto/sha1" // #nosec See docs for KDFRFC5054 for warnings.
 	"math/big"
 	"strings"
 	"unicode"
@@ -51,13 +51,9 @@ func KDFRFC5054(salt []byte, username string, password string) (x *big.Int) {
 // and normalizes to unicode NFKD
 func PreparePassword(s string) string {
 	var out string
-	// step #1: normalize `NFKD`
 	out = string(norm.NFKD.Bytes([]byte(s)))
-	// step #2: trim left
 	out = strings.TrimLeftFunc(out, unicode.IsSpace)
-	// step #3: trim right
 	out = strings.TrimRightFunc(out, unicode.IsSpace)
-	// step #4: return the result
 	return out
 }
 

--- a/proof.go
+++ b/proof.go
@@ -41,12 +41,24 @@ func (s *SRP) M(salt []byte, uname string) ([]byte, error) {
 	uHash := sha256.Sum256([]byte(uname))
 	h := sha256.New()
 
-	h.Write(groupHash[:])
-	h.Write(uHash[:])
-	h.Write(salt)
-	h.Write(s.ephemeralPublicA.Bytes())
-	h.Write(s.ephemeralPublicB.Bytes())
-	h.Write(s.key)
+	if _, err := h.Write(groupHash[:]); err != nil {
+		return nil, fmt.Errorf("failsed to write group hash to hasher: %v", err)
+	}
+	if _, err := h.Write(uHash[:]); err != nil {
+		return nil, fmt.Errorf("failsed to write u hash to hasher: %v", err)
+	}
+	if _, err := h.Write(salt); err != nil {
+		return nil, fmt.Errorf("failsed to write salt to hasher: %v", err)
+	}
+	if _, err := h.Write(s.ephemeralPublicA.Bytes()); err != nil {
+		return nil, fmt.Errorf("failsed to write A to hasher: %v", err)
+	}
+	if _, err := h.Write(s.ephemeralPublicB.Bytes()); err != nil {
+		return nil, fmt.Errorf("failsed to write B to hasher: %v", err)
+	}
+	if _, err := h.Write(s.key); err != nil {
+		return nil, fmt.Errorf("failsed to write key to hasher: %v", err)
+	}
 
 	s.m = h.Sum(nil)
 	return s.m, nil
@@ -78,9 +90,18 @@ func (s *SRP) ClientProof() ([]byte, error) {
 		return nil, fmt.Errorf("not enough pieces in place to construct client proof")
 	}
 	h := sha256.New()
-	h.Write(s.ephemeralPublicA.Bytes())
-	h.Write(s.m)
-	h.Write(s.key)
+	_, err := h.Write(s.ephemeralPublicA.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("failsed to write A to hasher: %v", err)
+	}
+	_, err = h.Write(s.m)
+	if err != nil {
+		return nil, fmt.Errorf("failsed to write M to hasher: %v", err)
+	}
+	_, err = h.Write(s.key)
+	if err != nil {
+		return nil, fmt.Errorf("failsed to write key to hasher: %v", err)
+	}
 	s.cProof = h.Sum(nil)
 	return s.cProof, nil
 }

--- a/proof.go
+++ b/proof.go
@@ -42,22 +42,22 @@ func (s *SRP) M(salt []byte, uname string) ([]byte, error) {
 	h := sha256.New()
 
 	if _, err := h.Write(groupHash[:]); err != nil {
-		return nil, fmt.Errorf("failsed to write group hash to hasher: %v", err)
+		return nil, fmt.Errorf("failed to write group hash to hasher: %v", err)
 	}
 	if _, err := h.Write(uHash[:]); err != nil {
-		return nil, fmt.Errorf("failsed to write u hash to hasher: %v", err)
+		return nil, fmt.Errorf("failed to write u hash to hasher: %v", err)
 	}
 	if _, err := h.Write(salt); err != nil {
-		return nil, fmt.Errorf("failsed to write salt to hasher: %v", err)
+		return nil, fmt.Errorf("failed to write salt to hasher: %v", err)
 	}
 	if _, err := h.Write(s.ephemeralPublicA.Bytes()); err != nil {
-		return nil, fmt.Errorf("failsed to write A to hasher: %v", err)
+		return nil, fmt.Errorf("failed to write A to hasher: %v", err)
 	}
 	if _, err := h.Write(s.ephemeralPublicB.Bytes()); err != nil {
-		return nil, fmt.Errorf("failsed to write B to hasher: %v", err)
+		return nil, fmt.Errorf("failed to write B to hasher: %v", err)
 	}
 	if _, err := h.Write(s.key); err != nil {
-		return nil, fmt.Errorf("failsed to write key to hasher: %v", err)
+		return nil, fmt.Errorf("failed to write key to hasher: %v", err)
 	}
 
 	s.m = h.Sum(nil)
@@ -92,15 +92,15 @@ func (s *SRP) ClientProof() ([]byte, error) {
 	h := sha256.New()
 	_, err := h.Write(s.ephemeralPublicA.Bytes())
 	if err != nil {
-		return nil, fmt.Errorf("failsed to write A to hasher: %v", err)
+		return nil, fmt.Errorf("failed to write A to hasher: %v", err)
 	}
 	_, err = h.Write(s.m)
 	if err != nil {
-		return nil, fmt.Errorf("failsed to write M to hasher: %v", err)
+		return nil, fmt.Errorf("failed to write M to hasher: %v", err)
 	}
 	_, err = h.Write(s.key)
 	if err != nil {
-		return nil, fmt.Errorf("failsed to write key to hasher: %v", err)
+		return nil, fmt.Errorf("failed to write key to hasher: %v", err)
 	}
 	s.cProof = h.Sum(nil)
 	return s.cProof, nil

--- a/srp.go
+++ b/srp.go
@@ -301,7 +301,9 @@ func (s *SRP) Key() ([]byte, error) {
 	s.premasterKey.Exp(b, e, s.group.n)
 
 	h := sha256.New()
-	h.Write([]byte(fmt.Sprintf("%x", s.premasterKey)))
+	if _, err := h.Write([]byte(fmt.Sprintf("%x", s.premasterKey))); err != nil {
+		return nil, fmt.Errorf("failed to write premasterKey to hasher: %v", err)
+	}
 
 	s.key = h.Sum(nil)
 

--- a/srp.go
+++ b/srp.go
@@ -254,6 +254,10 @@ func (s *SRP) Key() ([]byte, error) {
 	if s.group == nil {
 		return nil, fmt.Errorf("group not set")
 	}
+	// This test is so I'm not lying to gosec wrt to G105
+	if s.group.n.Cmp(bigZero) == 0 {
+		return nil, fmt.Errorf("group has 0 modulus")
+	}
 	// Because of tests, we don't want to always recalculate u
 	if !s.isUValid() {
 		if u, err := s.calculateU(); u == nil || err != nil {
@@ -277,7 +281,7 @@ func (s *SRP) Key() ([]byte, error) {
 		if s.v == nil || s.ephemeralPublicA == nil {
 			return nil, fmt.Errorf("not enough is known to create Key")
 		}
-		b.Exp(s.v, s.u, s.group.n)
+		b.Exp(s.v, s.u, s.group.n) // #nosec G105
 		b.Mul(b, s.ephemeralPublicA)
 		e = s.ephemeralPrivate
 	} else { // client
@@ -288,7 +292,7 @@ func (s *SRP) Key() ([]byte, error) {
 		e.Mul(s.u, s.x)
 		e.Add(e, s.ephemeralPrivate)
 
-		b.Exp(s.group.g, s.x, s.group.n)
+		b.Exp(s.group.g, s.x, s.group.n) // #nosec G105
 		b.Mul(b, s.k)
 		b.Sub(s.ephemeralPublicB, b)
 		b.Mod(b, s.group.n)


### PR DESCRIPTION
After running https://github.com/securego/gosec on this, I found a number of places where we could 

1. Do better error checking
2. Explicitly check that modulus for big.Exp isn't zero with the method that Exp is called.
3. Add some `#nosec` tags to suppress warnings on crypto "choices" in the KDFRFC5054
4. Panic if can't get random bytes

There are remaining places where error checking should be improved, but those will take a bit more thought on how to fix. So this PR is just getting the low handing fruit.
