### PR TITLE
Docs should point to canonical location of this repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # srp – A Go package for Secure Remote Password
 
-[![GoDoc: Reference](https://godoc.org/github.com/1password/srp?status.svg)](https://godoc.org/github.com/agilebits/srp) [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![GoDoc: Reference](https://godoc.org/github.com/1Password/srp?status.svg)](https://godoc.org/github.com/1Password/srp) [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
 
 srp is a [Go language](https://golang.org) package for Secure Remote Password (SRP). It is an implementation of:
@@ -17,12 +17,12 @@ It was developed by AgileBits to support part of the [1Password](https://1passwo
 To install srp, use `go get`:
 
 ```bash
-go get github.com/1password/srp
+go get github.com/1Password/srp
 ```
 
 Although the focus of this implementation is safety and ease of use (as opposed to speed), like all cryptographic tools, some understanding of its operation is required to not shoot yourself in the foot.
 
-**Read the [package documentation](https://godoc.org/github.com/1password/srp) for a discussion of user security responsibilities.**
+**Read the [package documentation](https://godoc.org/github.com/1Password/srp) for a discussion of user security responsibilities.**
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # srp – A Go package for Secure Remote Password
 
-[![GoDoc: Reference](https://godoc.org/github.com/agilebits/srp?status.svg)](https://godoc.org/github.com/agilebits/srp) [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![GoDoc: Reference](https://godoc.org/github.com/1password/srp?status.svg)](https://godoc.org/github.com/agilebits/srp) [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
 
 srp is a [Go language](https://golang.org) package for Secure Remote Password (SRP). It is an implementation of:
@@ -17,13 +17,21 @@ It was developed by AgileBits to support part of the [1Password](https://1passwo
 To install srp, use `go get`:
 
 ```bash
-go get github.com/agilebits/srp
+go get github.com/1password/srp
 ```
 
 Although the focus of this implementation is safety and ease of use (as opposed to speed), like all cryptographic tools, some understanding of its operation is required to not shoot yourself in the foot.
 
-**Read the [package documentation](https://godoc.org/github.com/agilebits/srp) for a discussion of user security responsibilities.**
+**Read the [package documentation](https://godoc.org/github.com/1password/srp) for a discussion of user security responsibilities.**
 
 ## Contribute
 
 Issues are appreciated. Forks leading to pull requests are appreciated even more. 😎
+
+## Gosec scans
+
+To run the [securego/gosec](https://github.com/securego/gosec) tool you need to have that installed. Then simply
+
+```
+gosec -fmt=json -out=path/to/where/you/want/results.json ./...
+```

--- a/doc.go
+++ b/doc.go
@@ -111,6 +111,6 @@ A captured v can be used to masquerade as the server and be used like a password
 4. Both: Proving to each other that both have the same key. The package includes methods
 that can assist with that.
 */
-package srp
+package srp // import "github.com/1password/srp"
 
 // This file is just for the package documentation


### PR DESCRIPTION
When we moved this repository from `github.com/agilebits/srp` to ``github.com/1Password/srp` we left lots of pointer to the old location. This PR does the following two things.

1. It updates the README to refer to the correct repository location
2. It adds an "import comment", which tells various go related tools what the canonical location for the repository should be.

It makes no code changes.