### PR TITLE
Explicitly trim hex where needed.

### DIFF
--- a/internal.go
+++ b/internal.go
@@ -163,10 +163,8 @@ func (s *SRP) calculateU() (*big.Int, error) {
 
 	h := sha256.New()
 
-	// Explicitely (instead of implicitly) trim leading "0"s from the hex representations
-	// For historical reasons clients expect this, but we are now doing so explicitly
-	trimmedHexPublicA := strings.TrimLeft(hex.EncodeToString(s.ephemeralPublicA.Bytes()), "0")
-	trimmedHexPublicB := strings.TrimLeft(hex.EncodeToString(s.ephemeralPublicB.Bytes()), "0")
+	trimmedHexPublicA := serverStyleHexFromBigInt(s.ephemeralPublicA)
+	trimmedHexPublicB := serverStyleHexFromBigInt(s.ephemeralPublicB)
 
 	_, err := h.Write([]byte(fmt.Sprintf("%s%s", trimmedHexPublicA, trimmedHexPublicB)))
 	if err != nil {
@@ -179,6 +177,21 @@ func (s *SRP) calculateU() (*big.Int, error) {
 		return nil, fmt.Errorf("u == 0, which is a bad thing")
 	}
 	return s.u, nil
+}
+
+// Convert a bigInt to a lowercase hex string with leading "0"s removed.
+// We do this explicitly instead of as an artifact of fmt.Sprintf
+func serverStyleHexFromBigInt(bn *big.Int) string {
+
+	// Don't worry. The compiler will build things the same even if we didn't create
+	// all of the intermediate variables below. And this better communicates all thes
+	// things we are doing to construct these strings
+	b := bn.Bytes()
+	h := hex.EncodeToString(b)
+	l := strings.ToLower(h)
+	res := strings.TrimLeft(l, "0")
+
+	return res
 }
 
 /**

--- a/internal.go
+++ b/internal.go
@@ -154,7 +154,7 @@ func (s *SRP) makeVerifier() (*big.Int, error) {
 // BUG(jpg): Calculation of u does not use RFC 5054 compatable padding/hashing
 // The scheme we use (see source) is to use SHA256 of the concatenation of A and B
 // each represented as a lowercase hexadecimal string.
-// additionally those hex strings have leading "0" removed even if that makes them of odd length
+// Additionally those hex strings have leading "0" removed even if that makes them of odd length
 func (s *SRP) calculateU() (*big.Int, error) {
 	if !s.IsPublicValid(s.ephemeralPublicA) || !s.IsPublicValid(s.ephemeralPublicB) {
 		s.u = nil
@@ -195,6 +195,6 @@ func serverStyleHexFromBigInt(bn *big.Int) string {
 }
 
 /**
- ** Copyright 2017 AgileBits, Inc.
+ ** Copyright 2017, 2020 AgileBits, Inc.
  ** Licensed under the Apache License, Version 2.0 (the "License").
  **/

--- a/srp_test.go
+++ b/srp_test.go
@@ -330,7 +330,97 @@ func TestMaxInt(t *testing.T) {
 	}
 }
 
+func TestCalculateU(t *testing.T) {
+	v := big.NewInt(42)   // value doesn't matter for this test
+	k := big.NewInt(2038) // End of the world. Value doesn't matter
+
+	// These are designed to test various combinations of the removing leading "0"s
+	testStrings := []string{
+		"0123456789ab", // these fail (probably my expectations are wrong)
+		"123456789abd",
+		"0fff12341234",
+		"ffff12341234",
+		"00123456789abd",
+		"123456789abcdef0",
+	}
+
+	// I probably should have saved the shell scripting that was involved in creating these tests
+	expected := map[string]map[string]string{
+		"0123456789ab": map[string]string{
+			"0123456789ab":     "3473b093f4dbc722b2888a959bbea9900930a37b551a87f0dacb5b8e7cc25716",
+			"123456789abd":     "90e6c973cdc0fd7e1e46c175a96b097aa028c609735c7b8e22cc2ad73d4f3562",
+			"00123456789abd":   "90e6c973cdc0fd7e1e46c175a96b097aa028c609735c7b8e22cc2ad73d4f3562",
+			"0fff12341234":     "531757fcb6b4777079de5c16ec0c7cc34e9d9a87231e45d3880bae20ecfbca6c",
+			"ffff12341234":     "a4e46ec489660092000f88f2f313630c198583f4609b1d731b4c12f8a13d1aae",
+			"123456789abcdef0": "d469afdb6b53eae515a3b90bd068f4b51a7c07ed3338a5b0f115568f189c92fa",
+		},
+		"123456789abd": map[string]string{
+			"0123456789ab":     "8316d6bb7c4948281828fc87b0a60b27131147acc9dd3884579dd373bc5fa66c",
+			"123456789abd":     "84a9d2f215c13ed60a5163fc1ae80720c5ee38994cb3c9e2c61f1d9c6769fee0",
+			"00123456789abd":   "84a9d2f215c13ed60a5163fc1ae80720c5ee38994cb3c9e2c61f1d9c6769fee0",
+			"0fff12341234":     "a1ba645a117a5b3f25c092db8de15cd6d1441e65fad076b6a724e9fa799e5e27",
+			"ffff12341234":     "dcd2d4db6b6b9374ece8218aa329f0d6af1916e3e7cd648ac69696f7b0fc35c8",
+			"123456789abcdef0": "f3b18867043bff3f8f70ded696a8f30641a6e978b64afac268fe5e0c218541b5",
+		},
+		"00123456789abd": map[string]string{
+			"0123456789ab":     "8316d6bb7c4948281828fc87b0a60b27131147acc9dd3884579dd373bc5fa66c",
+			"123456789abd":     "84a9d2f215c13ed60a5163fc1ae80720c5ee38994cb3c9e2c61f1d9c6769fee0",
+			"00123456789abd":   "84a9d2f215c13ed60a5163fc1ae80720c5ee38994cb3c9e2c61f1d9c6769fee0",
+			"0fff12341234":     "a1ba645a117a5b3f25c092db8de15cd6d1441e65fad076b6a724e9fa799e5e27",
+			"ffff12341234":     "dcd2d4db6b6b9374ece8218aa329f0d6af1916e3e7cd648ac69696f7b0fc35c8",
+			"123456789abcdef0": "f3b18867043bff3f8f70ded696a8f30641a6e978b64afac268fe5e0c218541b5",
+		},
+		"0fff12341234": map[string]string{
+			"0123456789ab":     "a8b75aa42a37697190b7ee3d4a94767d824833b09a67f4a000baa91b4c299bbf",
+			"123456789abd":     "e3fe08e9dd54a7fc45cef7fce898cfe5d13761180d39ae2ce09d291de84e24f0",
+			"00123456789abd":   "e3fe08e9dd54a7fc45cef7fce898cfe5d13761180d39ae2ce09d291de84e24f0",
+			"0fff12341234":     "8b71aac3218c8ed169e8ea0a812a6285720cf9ae500213e74597d92035aca3b0",
+			"ffff12341234":     "f4f5f8c6136abb8f330c584cc4118ff4ab267a778f647488132e8247918cea5a",
+			"123456789abcdef0": "35d468540b4ec5b6d87c892c64c53f12133d95e3f7725738fe6aec849084ad94",
+		},
+		"ffff12341234": map[string]string{
+			"0123456789ab":     "c64ccc47ad0384b7319e77454c8222360517a187c4a65e14681e896fe33df91c",
+			"123456789abd":     "206b4ac4d451dbba7de2f31f321c4cdf08562ba42ef39d447ac74ffa62b4991e",
+			"00123456789abd":   "206b4ac4d451dbba7de2f31f321c4cdf08562ba42ef39d447ac74ffa62b4991e",
+			"0fff12341234":     "4525eb8e1689800db2cf63545ce2a331e4ffce73dccf4ff9cc76ebb1a4bb1370",
+			"ffff12341234":     "a4f7aea26de01ca96c679539ae8a5f85c84885c8df7d22323dcc5225ab5bd782",
+			"123456789abcdef0": "20e882a091216d709c6e3e59dcac4068912c82b401412b6c89105e16cd10960a",
+		},
+		"123456789abcdef0": map[string]string{
+			"0123456789ab":     "d1ffad6424b8e424ab930f37c42523371e639ccd40d25c49683590878345c4c2",
+			"123456789abd":     "2765d1ed7b227492795f830e9606875dfc2bb79cb7d047de0d8f57c577bb840e",
+			"00123456789abd":   "2765d1ed7b227492795f830e9606875dfc2bb79cb7d047de0d8f57c577bb840e",
+			"0fff12341234":     "d522edeb8c365db35685e997840fecc67d0a1edcfd170cf77271c42112959b63",
+			"ffff12341234":     "a2758e911a3286c99ab6c630c92cc4fa5330685dafa23a61005f07ccdb42084e",
+			"123456789abcdef0": "8c2f9fd27c0044c83e64bc66162be45810cadb85e774fb9ab5eaf26ea68f7fa8",
+		},
+	}
+
+	s := NewSRPServer(KnownGroups[RFC5054Group4096], v, k)
+	for _, A := range testStrings {
+		for _, B := range testStrings {
+
+			s.ephemeralPublicA = NumberFromString(A)
+			s.ephemeralPublicB = NumberFromString(B)
+
+			u, err := s.calculateU()
+			if err != nil {
+				t.Errorf("Failed to compute u on (%q, %q): %v", A, B, err)
+			}
+
+			// some test on u will happen here
+			uHex := hex.EncodeToString(u.Bytes())
+
+			if uHex != expected[A][B] {
+				t.Errorf("u(%s,%s) = %s\n\tExpected %s", A, B, uHex, expected[A][B])
+			}
+
+		}
+	}
+
+}
+
 /**
- ** Copyright 2017 AgileBits, Inc.
+ ** Copyright 2017, 2020 AgileBits, Inc.
  ** Licensed under the Apache License, Version 2.0 (the "License").
  **/


### PR DESCRIPTION
Turns out we've been implicitly trimming leading "0" from some hex representations before operating on those representations themselves. Clients have to perform the same math and have been doing the same.

This makes that implicit behavior explicit.