### PR TITLE
feat: return errors in exported functions instead of panicking

### DIFF
--- a/example_sharedkey_test.go
+++ b/example_sharedkey_test.go
@@ -54,10 +54,11 @@ func Example() {
 
 	// this is still our first use scenario, but the client needs to create
 	// an SRP client to generate the verifier.
-	firstClient := srp.NewSRPClient(srp.KnownGroups[group], x, nil)
-	if firstClient == nil {
-		log.Fatal("couldn't setup client")
+	firstClient, err := srp.NewSRPClient(srp.KnownGroups[group], x, nil)
+	if err != nil {
+		log.Fatalf("setting up client: %v", err)
 	}
+
 	v, err := firstClient.Verifier()
 	if err != nil {
 		log.Fatal(err)
@@ -77,16 +78,19 @@ func Example() {
 	// But here we will assume that that the client knows this, and already has
 	// computed x.
 
-	client := srp.NewSRPClient(srp.KnownGroups[group], x, nil)
+	client, err := srp.NewSRPClient(srp.KnownGroups[group], x, nil)
+	if err != nil {
+		log.Fatalf("setting up client: %v", err)
+	}
 
 	// The client will need to send its ephemeral public key to the server
 	// so we fetch that now.
 	A = client.EphemeralPublic()
 
 	// Now it is time for some stuff (though not much) on the server.
-	server := srp.NewSRPServer(srp.KnownGroups[group], v, nil)
-	if server == nil {
-		log.Fatal("Couldn't set up server")
+	server, err := srp.NewSRPServer(srp.KnownGroups[group], v, nil)
+	if err != nil {
+		log.Fatalf("setting up server: %v", err)
 	}
 
 	// The server will get A (clients ephemeral public key) from the client

--- a/example_sharedkey_test.go
+++ b/example_sharedkey_test.go
@@ -47,7 +47,10 @@ func Example() {
 	username := "fred@fred.example"
 
 	// You would use a better Key Derivation Function than this one
-	x := srp.KDFRFC5054(salt, username, pw) // Really. Don't use this KDF
+	x, err := srp.KDFRFC5054(salt, username, pw) // Really. Don't use this KDF
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// this is still our first use scenario, but the client needs to create
 	// an SRP client to generate the verifier.

--- a/kdf.go
+++ b/kdf.go
@@ -4,6 +4,7 @@ import (
 
 	// #nosec See docs for KDFRFC5054 for warnings.
 	"crypto/sha1"
+	"fmt"
 	"math/big"
 	"strings"
 	"unicode"
@@ -28,35 +29,50 @@ from  a username, password, and salt as described
 in RFC 5054 §2.6, which says
     x = SHA1(s | SHA1(I | ":" | P))
 */
-func KDFRFC5054(salt []byte, username string, password string) (x *big.Int) {
+func KDFRFC5054(salt []byte, username string, password string) (*big.Int, error) {
 	p := []byte(PreparePassword(password))
-
 	u := []byte(PreparePassword(username))
+	sep := []byte(":")
 
 	innerHasher := sha1.New() // #nosec
-	if _, err := innerHasher.Write(u); err != nil {
-		panic(err)
+
+	if n, err := innerHasher.Write(u); err != nil {
+		return nil, fmt.Errorf("writing username: %w", err)
+	} else if n != len(u) {
+		return nil, fmt.Errorf("could only write %d out of the %d username bytes", n, len(u))
 	}
-	if _, err := innerHasher.Write([]byte(":")); err != nil {
-		panic(err)
+
+	if n, err := innerHasher.Write(sep); err != nil {
+		return nil, fmt.Errorf("writing separator: %w", err)
+	} else if n != len(sep) {
+		return nil, fmt.Errorf("could only write %d out of the %d separator bytes", n, len(sep))
 	}
-	if _, err := innerHasher.Write(p); err != nil {
-		panic(err)
+
+	if n, err := innerHasher.Write(p); err != nil {
+		return nil, fmt.Errorf("writing password: %w", err)
+	} else if n != len(p) {
+		return nil, fmt.Errorf("could only write %d out of the %d password bytes", n, len(p))
 	}
 
 	ih := innerHasher.Sum(nil)
 
 	oHasher := sha1.New() // #nosec
-	if _, err := oHasher.Write(salt); err != nil {
-		panic(err)
+
+	if n, err := oHasher.Write(salt); err != nil {
+		return nil, fmt.Errorf("writing salt: %w", err)
+	} else if n != len(salt) {
+		return nil, fmt.Errorf("could only write %d out of the %d salt bytes", n, len(salt))
 	}
-	if _, err := oHasher.Write(ih); err != nil {
-		panic(err)
+
+	if n, err := oHasher.Write(ih); err != nil {
+		return nil, fmt.Errorf("writing inner hash: %w", err)
+	} else if n != len(ih) {
+		return nil, fmt.Errorf("could only write %d out of the %d inner hash bytes", n, len(ih))
 	}
 
 	h := oHasher.Sum(nil)
-	x = bigIntFromBytes(h)
-	return x
+
+	return bigIntFromBytes(h), nil
 }
 
 // PreparePassword strips leading and trailing white space

--- a/kdf_test.go
+++ b/kdf_test.go
@@ -35,7 +35,11 @@ func TestKDFRFC5054(t *testing.T) {
 	vec.salt = strings.ReplaceAll(vec.salt, " ", "")
 	s, _ := hex.DecodeString(vec.salt)
 
-	x := KDFRFC5054(s, vec.I, vec.P)
+	x, err := KDFRFC5054(s, vec.I, vec.P)
+	if err != nil {
+		t.Fatalf("KDFRFC5054: %v", err)
+	}
+
 	if expX.Cmp(x) != 0 {
 		t.Error("didn't derive correct x")
 	}

--- a/srp_test.go
+++ b/srp_test.go
@@ -57,7 +57,11 @@ func TestCalculateClientRawKey(t *testing.T) {
 	expectedKey, _ := hex.DecodeString("f6bef3d6fa5a08a849bf61041cd5b3185c16aede851c819a3644fa7e918c4da6")
 
 	groupID := RFC5054Group4096
-	client := NewSRPClient(KnownGroups[groupID], x, k)
+	client, err := NewSRPClient(KnownGroups[groupID], x, k)
+	if err != nil {
+		t.Fatalf("setting up client: %v", err)
+	}
+
 	client.ephemeralPrivate = a
 	if _, err := client.makeA(); err != nil {
 		t.Error(err)
@@ -74,9 +78,11 @@ func TestCalculateClientRawKey(t *testing.T) {
 }
 
 func TestNewSRPClient(t *testing.T) {
-	var err error
 	x := NumberFromString("740299d2306764ad9e87f37cd54179e388fd45c85fea3b030eb425d7adcb2773")
-	s := NewSRPClient(KnownGroups[RFC5054Group4096], x, nil)
+	s, err := NewSRPClient(KnownGroups[RFC5054Group4096], x, nil)
+	if err != nil {
+		t.Fatalf("setting up client: %v", err)
+	}
 
 	expectedV4096 := NumberFromString("d05240ed513a4f267608e64cf2a84f5106741ddbf1435707a84f530207409d7" +
 		"af1e671182f9d77855b61c628df2b8f6ba8e9b6068fbc84fab80b4542f44c666e17358ebffa8d6fb00fd7037a" +
@@ -104,10 +110,13 @@ func TestNewSRPClient(t *testing.T) {
 }
 
 func TestSRPVerifier1024(t *testing.T) {
-	var err error
 	var clientV *big.Int
 	x := expectedX
-	s := NewSRPClient(KnownGroups[RFC5054Group1024], x, nil)
+
+	s, err := NewSRPClient(KnownGroups[RFC5054Group1024], x, nil)
+	if err != nil {
+		t.Fatalf("setting up client: %v", err)
+	}
 
 	if clientV, err = s.Verifier(); err != nil {
 		t.Errorf("couldn't make v: %s", err)
@@ -159,9 +168,11 @@ func TestNewSRPAgainstSpec(t *testing.T) {
 		"3499B200 210DCC1F 10EB3394 3CD67FC8 8A2F39A4 BE5BEC4E C0A3212D" +
 		"C346D7E4 74B29EDE 8A469FFE CA686E5A")
 
-	server := NewSRPServer(KnownGroups[groupID], v, k)
+	server, err := NewSRPServer(KnownGroups[groupID], v, k)
+	if err != nil {
+		t.Fatalf("setting up server: %v", err)
+	}
 
-	var err error
 	var ret *big.Int
 	var retBytes []byte
 
@@ -212,7 +223,10 @@ func TestNewSRPAgainstSpec(t *testing.T) {
 
 	// Now lets compute the key from the client side
 
-	client := NewSRPClient(KnownGroups[groupID], x, k)
+	client, err := NewSRPClient(KnownGroups[groupID], x, k)
+	if err != nil {
+		t.Fatalf("setting up client: %v", err)
+	}
 
 	// Force use of test vector a
 	client.ephemeralPrivate = a
@@ -255,13 +269,19 @@ func TestClientServerMatch(t *testing.T) {
 	x := &big.Int{}
 	x.SetBytes(xbytes)
 
-	client := NewSRPClient(KnownGroups[groupID], x, nil)
+	client, err := NewSRPClient(KnownGroups[groupID], x, nil)
+	if err != nil {
+		t.Fatalf("setting up client: %v", err)
+	}
 
 	if v, err = client.Verifier(); err != nil {
 		t.Errorf("verifier creation failed: %s", err)
 	}
 
-	server := NewSRPServer(KnownGroups[groupID], v, nil)
+	server, err := NewSRPServer(KnownGroups[groupID], v, nil)
+	if err != nil {
+		t.Fatalf("setting up server: %v", err)
+	}
 
 	A := client.EphemeralPublic()
 	B := server.EphemeralPublic()
@@ -294,7 +314,10 @@ func TestBadA(t *testing.T) {
 	v := &big.Int{}
 	v.SetBytes(xbytes)
 
-	server := NewSRPServer(KnownGroups[RFC5054Group2048], v, nil)
+	server, err := NewSRPServer(KnownGroups[RFC5054Group2048], v, nil)
+	if err != nil {
+		t.Fatalf("setting up server: %v", err)
+	}
 
 	if err := server.SetOthersPublic(server.group.n); err == nil {
 		t.Error("a bad A was accepted")
@@ -397,7 +420,11 @@ func TestCalculateU(t *testing.T) {
 		},
 	}
 
-	s := NewSRPServer(KnownGroups[RFC5054Group4096], v, k)
+	s, err := NewSRPServer(KnownGroups[RFC5054Group4096], v, k)
+	if err != nil {
+		t.Fatalf("setting up server: %v", err)
+	}
+
 	for _, A := range testStrings {
 		for _, B := range testStrings {
 			s.ephemeralPublicA = NumberFromString(A)


### PR DESCRIPTION
👋🏽 hi team

### What
This PR proposes braking changes to some of the exported functions ⚠️
Namely, `NewSRPClient()`, `NewSRPServer()`, and `KDFRFC5054()`.

Concretely, it changes the signature of these methods so that they return an error (a common Go idiom), rather than panicking. This allows consumers of the library to handle the errors gracefully and at their convinience.

### What approach did you choose and why?
I identified all the places where we panic. I refactored it to emit an error instead. I then worked my way upwards so that the error gets bubbled up all the way to the exported functions.

### What should reviewers focus on?
I believe there is much to be gained from this breaking change:
- a review of the release process for this library: from what I can tell there are no release docs
- adhering to one of the core Go idioms: [don't panic](https://github.com/golang/go/wiki/CodeReviewComments#dont-panic)

So the questions I think we should focus on are (if the changes are approved):
- how are we going to roll out this change?
- do we want to notify [public consumers](https://github.com/1Password/srp/network/dependents?package_id=UGFja2FnZS0yMjY3MzU3NDAz) of this library?

### If something goes wrong, what are the mitigation strategies?
Consumers of this library can use the previous tag or a commit SHA prior to this PR.

Note that I am not an official collaborator on this repo, so my commits won't trigger CI builds. If you want to see the CI for these commits, see my fork: https://github.com/CamiloGarciaLaRotta/srp/pull/2/commits

### Performance Impact
None

### Observability 
N/A