### PR TITLE
Make linter happy

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,6 @@ linters:
     - testpackage
     - varnamelen
     - wsl
-    - nonamedreturns
     # deprecated
     - golint
     - interfacer

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
     - testpackage
     - varnamelen
     - wsl
+    - nonamedreturns
     # deprecated
     - golint
     - interfacer

--- a/group.go
+++ b/group.go
@@ -17,14 +17,6 @@ type Group struct {
 	ExponentSize int // RFC 3526 §8
 }
 
-// NewGroup creates and initializes a an SRP group.
-func NewGroup() *Group {
-	return &Group{
-		g: &big.Int{},
-		n: &big.Int{},
-	}
-}
-
 // N returns the modulus of the the group.
 func (g *Group) N() *big.Int {
 	return g.n

--- a/srp.go
+++ b/srp.go
@@ -335,6 +335,7 @@ func (s *SRP) Key() ([]byte, error) {
 	return s.key, nil
 }
 
+//nolint:exhaustruct
 var (
 	_ encoding.BinaryMarshaler   = &SRP{}
 	_ encoding.BinaryUnmarshaler = &SRP{}

--- a/srp_test.go
+++ b/srp_test.go
@@ -21,6 +21,7 @@ var expectedVerifier = hexNumberString(
 		"EA53D15C 1AFF87B2 B9DA6E04 E058AD51 CC72BFC9 033B564E 26480D78" +
 		"E955A5E2 9E7AB245 DB2BE315 E2099AFB")
 
+//nolint:exhaustruct
 var g1024 = &Group{g: big.NewInt(2), n: NumberFromString("0x EEAF0AB9ADB38DD69C33F80AFA8FC5E86072618775FF3C0B9EA2314C" +
 	"9C256576D674DF7496EA81D3383B4813D692C6E0E0D5D8E250B98BE4" +
 	"8E495C1D6089DAD15DC7D7B46154D6B6CE8EF4AD69B15D4982559B29" +
@@ -469,7 +470,7 @@ func TestSRP_Marshal_Unmarshal_Binary(t *testing.T) {
 		t.Errorf("Resulting byte array was empty")
 	}
 
-	newServer := &SRP{}
+	newServer := &SRP{} //nolint:exhaustruct
 	err = newServer.UnmarshalBinary(data)
 	if err != nil {
 		t.Errorf("Failed to unmarshal binary data into SRP: %+v", err)


### PR DESCRIPTION
Mostly just `//nolint` comments 

Note that for some reason nonamedreturns runs when I run `golangci-lint` locally if I don't add it to the disable list. But it isn't called on GitHub. So the issue #48 that sparked this PR is not an issue